### PR TITLE
Jr fast empty downb

### DIFF
--- a/fighters/koopajr/src/acmd/specials.rs
+++ b/fighters/koopajr/src/acmd/specials.rs
@@ -6,16 +6,28 @@ use super::*;
 unsafe fn koopajr_special_lw_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
+    frame(lua_state, 1.0);
+    if is_excute(fighter) {
+        if ArticleModule::is_exist(boma, *FIGHTER_KOOPAJR_GENERATE_ARTICLE_MECHAKOOPA) {
+            MotionModule::set_rate(boma, 2.0);
+        }
+    }
     frame(lua_state, 10.0);
     if is_excute(fighter) {
         ArticleModule::generate_article(boma, *FIGHTER_KOOPAJR_GENERATE_ARTICLE_MECHAKOOPA, false, 0);
     }
 }
 
-#[acmd_script( agent = "koopajr", script = "game_specialirlw" , category = ACMD_GAME , low_priority)]
+#[acmd_script( agent = "koopajr", script = "game_specialairlw" , category = ACMD_GAME , low_priority)]
 unsafe fn koopajr_special_air_lw_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
+    frame(lua_state, 1.0);
+    if is_excute(fighter) {
+        if ArticleModule::is_exist(boma, *FIGHTER_KOOPAJR_GENERATE_ARTICLE_MECHAKOOPA) {
+            MotionModule::set_rate(boma, 2.0);
+        }
+    }
     frame(lua_state, 10.0);
     if is_excute(fighter) {
         ArticleModule::generate_article(boma, *FIGHTER_KOOPAJR_GENERATE_ARTICLE_MECHAKOOPA, false, 0);

--- a/fighters/koopajr/src/acmd/specials.rs
+++ b/fighters/koopajr/src/acmd/specials.rs
@@ -9,7 +9,7 @@ unsafe fn koopajr_special_lw_game(fighter: &mut L2CAgentBase) {
     frame(lua_state, 1.0);
     if is_excute(fighter) {
         if ArticleModule::is_exist(boma, *FIGHTER_KOOPAJR_GENERATE_ARTICLE_MECHAKOOPA) {
-            MotionModule::set_rate(boma, 2.0);
+            FT_MOTION_RATE(fighter, 0.66);
         }
     }
     frame(lua_state, 10.0);
@@ -25,7 +25,7 @@ unsafe fn koopajr_special_air_lw_game(fighter: &mut L2CAgentBase) {
     frame(lua_state, 1.0);
     if is_excute(fighter) {
         if ArticleModule::is_exist(boma, *FIGHTER_KOOPAJR_GENERATE_ARTICLE_MECHAKOOPA) {
-            MotionModule::set_rate(boma, 2.0);
+            FT_MOTION_RATE(fighter, 0.66);
         }
     }
     frame(lua_state, 10.0);


### PR DESCRIPTION
When Bowser Jr uses Down B while a mechakoopa is already out (and so the move will do nothing), the move will be sped up by 50% (FAF 30f -> 20f), giving it some utility if combined with b-reversing for some ankle breaking.